### PR TITLE
Deploy mvn site output to gh-pages

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  release:
-    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -42,4 +42,4 @@ jobs:
                   ]'
 
     - name: Build and deploy maven site
-      run: mvn -B -P reporting,publish-site surefire-report:report site site:jar deploy
+      run: mvn -B -P reporting surefire-report:report site site:stage scm-publish:publish-scm

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-## GeoServer GRASS raster datastore
+# GeoServer GRASS raster datastore
 
-Prerequisites: Java 11 and maven 3.5
+Combining the C- and Java-tribe FOSS4G greatness of [GRASS](https://grass.osgeo.org/) and
+[GeoServer](http://geoserver.org/).
+
+[![GRASS loves GeoServer!](https://mundialis.github.io/geoserver-grass-raster-datastore/images/grass-heart-geoserver.svg)](https://mundialis.github.io/geoserver-grass-raster-datastore)
+
+[ℹ️ Homepage](https://mundialis.github.io/geoserver-grass-raster-datastore/)
+
+## Prerequisites
+
+You'll need Java 11 and maven 3.5
 
 * build with `mvn install`
 * copy into Geoserver's `WEB-INF/lib` to enable
@@ -18,4 +27,13 @@ timeseries information (found in `tgis/sqlite.db` inside the mapset containing t
 In case of a timeseries raster dataset you may get multiple layers in case you have multiple timeseries stored in the
 database. When publishing a layer, make sure to enable WMS-TIME-support by checking the box in the dimensions tab.
 
-For more usage instructions, see [here](https://github.com/mundialis/geoserver-grass-raster-datastore/blob/master/src/site/markdown/index.md).
+For more usage instructions, have a [look at the homepage](https://mundialis.github.io/geoserver-grass-raster-datastore/).
+
+## Acknowledgements
+
+This work has been co-financed under Grant Agreement Connecting Europe Facility (CEF) Telecom project 2018-EU-IA-0095
+by the European Union (https://ec.europa.eu/inea/en/connecting-europe-facility/cef-telecom/2018-eu-ia-0095).
+
+This work has been partly developed as joint contribution of mundialis and terrestris to the
+[mFUND](https://www.bmvi.de/SharedDocs/DE/Artikel/DG/mfund-projekte/fair.html) project
+[Anwenderfreundliche Bereitstellung von Klima- und Wetterdaten – FAIR](https://www.fair-opendata.de/).

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
       <name>Nexus Snapshot Repository</name>
       <url>https://nexus.terrestris.de/repository/geoserver-extras/</url>
     </snapshotRepository>
+    <site>
+      <id>github</id>
+      <url>scm:git:git@github.com:mundialis/geoserver-grass-raster-datastore.git</url>
+    </site>
   </distributionManagement>
 
   <properties>
@@ -100,29 +104,6 @@
           </plugin>
         </plugins>
       </reporting>
-    </profile>
-    <profile>
-      <id>publish-site</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.github</groupId>
-            <artifactId>site-maven-plugin</artifactId>
-            <version>0.12</version>
-            <configuration>
-              <message>Creating site for ${project.version}</message>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>site</goal>
-                </goals>
-                <phase>deploy</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 
@@ -208,6 +189,14 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-publish-plugin</artifactId>
+          <version>3.1.0</version>
+          <configuration>
+            <scmBranch>gh-pages</scmBranch>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -3,7 +3,7 @@
 Combining the C- and Java-tribe FOSS4G greatness of [GRASS](https://grass.osgeo.org/) and
 [GeoServer](http://geoserver.org/).
 
-![GRASS loves GeoServer!](../resources/images/grass-heart-geoserver.svg)
+![GRASS loves GeoServer!](./images/grass-heart-geoserver.svg)
 
 _________________
 


### PR DESCRIPTION
This PR suggests to use a different way of publishing the output of `mvn site` to GitHub.

This works, try it e.g. locally by issuing

```
mvn -B -P reporting surefire-report:report site site:stage scm-publish:publish-scm
```

Here is the current live version: https://mundialis.github.io/geoserver-grass-raster-datastore/

I could not test the GitHub-action, any idea how to do that? We could also remove that commit and oinly manually update the gh-pages branch, I'll let others decide about that.

I do not know enough maven, to properly say that these changes make sense, so please review properly.

Thanks for any input in this.