### PR TITLE
Downgrade doxia-module-markdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
             <dependency>
               <groupId>org.apache.maven.doxia</groupId>
               <artifactId>doxia-module-markdown</artifactId>
-              <version>2.0.0-M3</version>
+              <version>2.0.0-M2</version>
             </dependency>
             <dependency>
               <groupId>org.apache.maven.wagon</groupId>


### PR DESCRIPTION
Upgrading to `M3` unfortunately causes this error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.12.0:site (default-site) on project geoserver-grass-raster-datastore: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.12.0:site failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-site-plugin:3.12.0:site: java.lang.IllegalAccessError: class org.apache.maven.doxia.module.markdown.MarkdownParser$MarkdownHtmlParser tried to access private field org.apache.maven.doxia.module.xhtml5.Xhtml5Parser.boxed (org.apache.maven.doxia.module.markdown.MarkdownParser$MarkdownHtmlParser and org.apache.maven.doxia.module.xhtml5.Xhtml5Parser are in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @6198e9b5)
[ERROR] -----------------------------------------------------
[ERROR] realm =    extension>org.apache.maven.plugins:maven-site-plugin:3.12.0
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
```

Please review @mundialis-dev 