### PR TITLE
Fix gdal version compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,7 @@
         <groupId>org.gdal</groupId>
         <artifactId>gdal</artifactId>
         <version>3.6.0</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/src/main/java/de/terrestris/hermosa/grass_gdal/GrassGdalReader.java
+++ b/src/main/java/de/terrestris/hermosa/grass_gdal/GrassGdalReader.java
@@ -318,6 +318,10 @@ public class GrassGdalReader extends AbstractGridCoverage2DReader {
           return null;
         }
 
+        if (gdal.VersionInfo().compareTo("3050000") < 0) {
+          finalSize = new int[]{dataset.getRasterXSize(), dataset.getRasterYSize()};
+        }
+
         WritableRaster raster = RasterFactory
           .createBandedRaster(dataBufferType, finalSize[0], finalSize[1], numBands, null);
 


### PR DESCRIPTION
Fixes version compatibility. For gdal versions <= 3.4 the calculation of the raster size must be done differently than for other versions.

@mundialis-dev Please review.